### PR TITLE
feat: add module discovery, GitHub ops, test orchestration, and reporting tools

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -11,3 +11,11 @@ DEFAULT_SUBSCRIPTION_ID=
 # Behaviour
 CLEANUP_ON_COMPLETE=true
 TEST_RG_PREFIX=rg-avm-test-
+
+# Runtime mode (set to true when hosted on Foundry)
+FOUNDRY_HOSTED=false
+
+# MCP connections (Foundry-hosted mode only)
+GITHUB_MCP_CONNECTION_ID=
+AZURE_MCP_CONNECTION_ID=
+EVA_MCP_SERVER_URL=

--- a/README.md
+++ b/README.md
@@ -1,14 +1,29 @@
 # Infrastructure Testing Agent
 
-A Microsoft Foundry hosted agent that tests Terraform / AVM module upgrades by deploying the current version, planning the new version, and producing a structured diff report.
+A Microsoft Foundry hosted agent that tests Terraform / AVM module upgrades by deploying, checking idempotency, analysing plan diffs, and reporting findings via GitHub.
 
 Built with the [Microsoft Agent Framework](https://github.com/microsoft/agent-framework) (Python).
+
+## Architecture
+
+```
+MCP Servers (GitHub, Azure, EVA/AzAPI)
+         │
+    Testing Agent (this repo)
+         │  reads skills, examples, UPGRADE.md
+    Module Under Test (MUT)
+```
+
+**Key principle:** Read, Don't Duplicate — the agent reads domain knowledge
+(AzAPI patterns, test conventions, AVM workflow) from the MUT's `.agents/skills/`
+directory at runtime, rather than embedding its own copy.
 
 ## Prerequisites
 
 - Python 3.12+
 - [Terraform CLI](https://developer.hashicorp.com/terraform/install)
 - [Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) (logged in)
+- [GitHub CLI](https://cli.github.com/) (for issue/PR operations)
 - A [Microsoft Foundry](https://learn.microsoft.com/azure/ai-services/agents/) project with a GPT-4.1 (or compatible) model deployment
 
 ## Quick Start
@@ -43,6 +58,10 @@ The agent listens on `http://localhost:8088` and exposes an OpenAI Responses-com
 | `DEFAULT_SUBSCRIPTION_ID` | No | — | Target subscription for deployments |
 | `CLEANUP_ON_COMPLETE` | No | `true` | Destroy resources after testing |
 | `TEST_RG_PREFIX` | No | `rg-avm-test-` | Prefix for test resource groups |
+| `FOUNDRY_HOSTED` | No | `false` | Enable Foundry-hosted mode with MCP |
+| `GITHUB_MCP_CONNECTION_ID` | No | — | Foundry connection for GitHub MCP |
+| `AZURE_MCP_CONNECTION_ID` | No | — | Foundry connection for Azure MCP |
+| `EVA_MCP_SERVER_URL` | No | — | EVA/AzAPI MCP server endpoint |
 
 ## Tools
 
@@ -50,11 +69,15 @@ The agent exposes the following tool groups to the LLM:
 
 | Group | Tools | Purpose |
 |-------|-------|---------|
-| Terraform | init, plan, apply, destroy, show, output, test | Core Terraform CLI operations |
+| Terraform | init, init-upgrade, plan, plan-json, apply, destroy, show, output, test, idempotency check | Core Terraform CLI operations |
 | Workspace | create, delete, list/read/write files | Isolated temp directories for each test |
 | Azure | resource group CRUD, identity check, RBAC check | Azure resource lifecycle |
 | Git | clone repo, clone registry module | Fetch module source code |
+| Module Discovery | ingest local, discover structure, read skills, list examples | Scan MUT for examples, tests, skills |
 | Analysis | summarise plan JSON, read UPGRADE.md | Structured diff and documentation review |
+| GitHub | create issue, create PR, add comment, search issues, get release | File bugs and propose changes |
+| Reporting | test report, issue body, upgrade doc suggestion | Format findings for output |
+| AVM CLI | run avm commands | Run MUT's own pre-commit, test runners |
 
 ## Docker
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,9 +1,14 @@
 # Infrastructure Testing Agent — Roadmap
 
-## Phase 1: Module Upgrade Testing (current) ✅ scaffolded
+## Architecture
 
-Core capability: deploy an existing AVM module version, plan the upgrade to a
-new version, and produce a structured diff report.
+Three-layer separation: MCP Servers → Testing Agent → Module Under Test (MUT).
+The agent reads skills and knowledge from the MUT at runtime (Read, Don't
+Duplicate). Multi-agent topology planned for phases 3-4.
+
+## Phase 1: Foundation ✅ scaffolded → 🚧 enhanced
+
+Core tools and module discovery.
 
 - [x] Project scaffold (Dockerfile, agent.yaml, config, main.py)
 - [x] Workspace management tools (create, delete, list, read, write files)
@@ -12,50 +17,43 @@ new version, and produce a structured diff report.
 - [x] Analysis tools (summarise plan JSON, read UPGRADE.md)
 - [x] Azure tools (resource group CRUD, identity check, RBAC check)
 - [x] System instructions with workflow conventions
+- [x] Module discovery tools (ingest local, discover structure, read skills)
+- [x] Idempotency check tool (apply → plan → assert empty)
+- [x] Structured plan output (terraform_plan_json)
+- [x] AVM CLI integration (run_avm_cli)
+- [x] GitHub operations (issues, PRs, comments, search via gh CLI)
+- [x] Reporting tools (test reports, issue bodies, UPGRADE.md suggestions)
+- [x] Shared data models (ModuleMap, DeployResult, AnalysisFinding, etc.)
+- [x] Config support for MCP connections and runtime modes
 - [ ] Local testing with mock/stub (no Azure dependency)
-- [ ] Idempotency check workflow (apply → plan → assert empty)
-- [ ] UPGRADE.md cross-reference reporting
-- [ ] Support specifying module examples (not just `default`)
 - [ ] End-to-end test with a real Foundry project + Application Gateway module
 
-## Phase 2: Enhanced Reporting
+## Phase 2: MCP Integration & Foundry Runtime
 
-- [ ] Structured JSON report output (machine-readable)
-- [ ] Markdown report generation (human-readable, suitable for PR comments)
-- [ ] Diff visualisation for plan changes
-- [ ] Cost estimation integration (e.g. Infracost)
-- [ ] Track test history across runs (via Foundry conversations)
+- [ ] MCP server declarations (GitHub, Azure, EVA/AzAPI)
+- [ ] Dual runtime mode (local ChatAgent vs Foundry AIProjectClient)
+- [ ] `runtime/local.py` and `runtime/foundry.py` modules
+- [ ] Connection-based auth for hosted mode
+- [ ] PromptAgentDefinition with structured inputs
 
-## Phase 3: Azure Landing Zone / Generic Module Testing
+## Phase 3: Multi-Agent Orchestration
 
-- [ ] `terraform test` integration (native testing framework)
-- [ ] Post-deploy validation via Azure Resource Graph queries
-- [ ] Integration test runner (deploy module A → check module B can connect)
-- [ ] Parameterised test scenarios (matrix of inputs/examples)
-- [ ] ALZ module dependency graph awareness
-- [ ] Compliance/policy check after deployment (Azure Policy)
+- [ ] Extract agents into `agents/` directory
+- [ ] Orchestrator with agent-as-tools pattern
+- [ ] Concurrent deploy agents (one per example)
+- [ ] Sequential analysis pipeline (Analysis → Reviewer → Reporter)
+- [ ] Structured handoff data between agents
+- [ ] Human-in-the-loop approval gates
 
-## Phase 4: CI/CD & GitHub Integration
+## Phase 4: Full Production
 
-- [ ] GitHub Actions workflow for triggering the agent
-- [ ] GitHub Agentic Workflows integration (when available)
-- [ ] PR comment integration (post test results as PR comments)
-- [ ] Webhook trigger support (deploy on PR open/update)
-- [ ] State management for tracking which module versions have been tested
-
-## Phase 5: Multi-Module & Composition Testing
-
-- [ ] Test module composition (deploy module A + module B together)
-- [ ] Cross-module dependency validation
-- [ ] Landing zone end-to-end deployment pipeline
-- [ ] Environment promotion testing (dev → staging config diffs)
-
-## Phase 6: Intelligence & Learning
-
-- [ ] Learn from previous test runs (common failure patterns)
-- [ ] Auto-generate UPGRADE.md content from plan diffs
-- [ ] Suggest fixes for common Terraform errors
-- [ ] Foundry evaluation integration (track agent quality over time)
+- [ ] A2ATool for published Foundry agents
+- [ ] Agent card discovery
+- [ ] Azure Landing Zone / composition module testing
+- [ ] Cost estimation integration
+- [ ] Compliance/policy checks after deployment
+- [ ] CI/CD triggers (GitHub Actions, webhooks)
+- [ ] Foundry evaluation integration (agent quality tracking)
 
 ## Infrastructure / Ops
 

--- a/config.py
+++ b/config.py
@@ -33,12 +33,38 @@ class AgentConfig:
         == "true"
     )
 
+    # MCP connections (Foundry-hosted mode)
+    github_mcp_connection_id: str = field(
+        default_factory=lambda: os.environ.get("GITHUB_MCP_CONNECTION_ID", "")
+    )
+    azure_mcp_connection_id: str = field(
+        default_factory=lambda: os.environ.get("AZURE_MCP_CONNECTION_ID", "")
+    )
+    eva_mcp_server_url: str = field(
+        default_factory=lambda: os.environ.get("EVA_MCP_SERVER_URL", "")
+    )
+
+    # Runtime mode
+    foundry_hosted: bool = field(
+        default_factory=lambda: os.environ.get("FOUNDRY_HOSTED", "false").lower()
+        == "true"
+    )
+
     def validate(self) -> list[str]:
         """Return a list of missing-but-required settings."""
         issues: list[str] = []
         if not self.project_endpoint:
             issues.append("AZURE_AI_PROJECT_ENDPOINT is not set")
         return issues
+
+    @property
+    def has_mcp(self) -> bool:
+        """Check if any MCP connections are configured."""
+        return bool(
+            self.github_mcp_connection_id
+            or self.azure_mcp_connection_id
+            or self.eva_mcp_server_url
+        )
 
 
 # Singleton used by tools

--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 
 A hosted agent built with the Microsoft Agent Framework that tests
 Terraform modules by deploying, planning, and analysing diffs.
+Supports local development and Foundry-hosted modes.
 """
 
 from __future__ import annotations
@@ -21,15 +22,19 @@ from config import config
 
 # Import all tool functions so the framework discovers them
 from tools.terraform import (
+    check_idempotency,
     create_workspace,
     delete_workspace,
     list_workspace_files,
     read_workspace_file,
+    run_avm_cli,
     terraform_apply,
     terraform_destroy,
     terraform_init,
+    terraform_init_upgrade,
     terraform_output,
     terraform_plan,
+    terraform_plan_json,
     terraform_show,
     terraform_test,
     write_workspace_file,
@@ -49,6 +54,24 @@ from tools.analysis import (
     read_upgrade_doc,
     summarise_plan_json,
 )
+from tools.module_discovery import (
+    discover_module_structure,
+    ingest_local_module,
+    list_module_examples,
+    read_module_skill,
+)
+from tools.github_ops import (
+    add_issue_comment,
+    create_github_issue,
+    create_pull_request,
+    get_latest_release,
+    search_github_issues,
+)
+from tools.reporting import (
+    generate_issue_body,
+    generate_test_report,
+    generate_upgrade_doc_suggestion,
+)
 
 SYSTEM_INSTRUCTIONS = """\
 You are an Infrastructure Testing Agent with expertise in Terraform, \
@@ -61,23 +84,54 @@ Your primary capabilities:
 2. **Idempotency Checking** — After applying a configuration, run a second \
    plan to verify no unexpected changes are detected.
 3. **Resource Lifecycle** — Create test resource groups, deploy, and clean up.
+4. **Module Discovery** — Scan a module to understand its structure, examples, \
+   tests, skills, and available tooling.
+5. **Reporting** — Generate structured test reports and file GitHub issues \
+   for findings.
 
-## Workflow Conventions
+## Module Discovery Workflow
+- When given a module to test, first call `ingest_local_module` (for local \
+  paths) or `clone_registry_module` (for registry modules) to load it.
+- Then call `discover_module_structure` to understand what's available: \
+  examples, tests, skill files, UPGRADE.md, AVM CLI, provider requirements.
+- Read `.agents/skills/.../example-test.md` (if present) using \
+  `read_module_skill` and follow its workflow for deploy testing.
+- Use the MUT's `./avm` CLI when available via `run_avm_cli` for \
+  pre-commit checks and test runners.
+
+## Knowledge Sources (DO NOT embed — query at runtime)
+- AzAPI patterns → read MUT's `.agents/skills/.../AzAPI.md`
+- ARM schemas → execute MUT's `azure-schema` CLI
+- Provider schemas → execute `tfpluginschema`
+- AVM conventions → read MUT's skill files via `read_module_skill`
+- Breaking changes → read `UPGRADE.md` via `read_upgrade_doc`
+
+## Testing Workflow
 - Always start by calling `create_workspace` to get an isolated working area.
-- Use `clone_registry_module` for official Terraform Registry modules and \
-  `clone_repo` for forks or GitHub-hosted versions.
+- Use `ingest_local_module` for local modules, `clone_registry_module` for \
+  registry modules, and `clone_repo` for GitHub-hosted modules.
 - Use the `default` example from a module unless the user specifies otherwise.
 - For module upgrades: deploy the old version first with terraform apply, \
-  then replace the module source with the new version and run terraform plan \
-  to capture the diff.
-- Always run a second `terraform plan` after `terraform apply` to check \
-  idempotency. Report any non-empty plan as a potential issue.
+  then update the source and run `terraform_plan_json` to capture a \
+  structured diff.
+- Always call `check_idempotency` after `terraform_apply` to verify no \
+  unexpected changes.
+- Use `terraform_init_upgrade` when testing module version upgrades.
 - Default behaviour is to destroy resources after testing \
   (CLEANUP_ON_COMPLETE=true). If the user asks to keep resources, skip destroy.
 - When creating resource groups, use the naming convention: \
   {TEST_RG_PREFIX}{module-short-name}-{random-suffix}
 - Tag all test resource groups with: purpose=infra-testing-agent, \
   managed-by=foundry-agent
+
+## Feedback Loop
+- After testing, use `generate_test_report` to produce a structured report.
+- Use `search_github_issues` before filing to avoid duplicates.
+- Use `generate_issue_body` to format findings, then `create_github_issue` \
+  to file bugs discovered during testing.
+- Use `generate_upgrade_doc_suggestion` when observed changes don't match \
+  UPGRADE.md documentation.
+- Use `add_issue_comment` to post results on existing tracking issues.
 
 ## Output Style
 - Be concise and structured in your reports.
@@ -103,12 +157,16 @@ ALL_TOOLS = [
     write_workspace_file,
     # Terraform
     terraform_init,
+    terraform_init_upgrade,
     terraform_plan,
+    terraform_plan_json,
     terraform_apply,
     terraform_destroy,
     terraform_show,
     terraform_output,
     terraform_test,
+    check_idempotency,
+    run_avm_cli,
     # Azure
     create_resource_group,
     delete_resource_group,
@@ -118,9 +176,24 @@ ALL_TOOLS = [
     # Git
     clone_repo,
     clone_registry_module,
+    # Module Discovery
+    ingest_local_module,
+    discover_module_structure,
+    read_module_skill,
+    list_module_examples,
     # Analysis
     read_upgrade_doc,
     summarise_plan_json,
+    # GitHub Operations
+    create_github_issue,
+    create_pull_request,
+    add_issue_comment,
+    search_github_issues,
+    get_latest_release,
+    # Reporting
+    generate_test_report,
+    generate_issue_body,
+    generate_upgrade_doc_suggestion,
 ]
 
 agent = ChatAgent(

--- a/models.py
+++ b/models.py
@@ -1,0 +1,124 @@
+"""Shared data models for structured handoffs between agent phases.
+
+These dataclasses define the contract for passing data between tools and
+(eventually) between agents in the multi-agent topology.  All tool output
+should use these models to avoid dumping raw terraform output into context.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict, dataclass, field
+from typing import Literal
+
+
+@dataclass
+class ModuleMap:
+    """Structured representation of a Module Under Test (MUT)."""
+
+    source_path: str
+    source_type: Literal["local", "registry", "git"]
+    examples: list[str] = field(default_factory=list)
+    tests: dict[str, list[str]] = field(default_factory=dict)
+    skills: list[str] = field(default_factory=list)
+    upgrade_md: str | None = None
+    avm_cli: bool = False
+    providers: dict[str, str] = field(default_factory=dict)
+    devcontainer_image: str | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+@dataclass
+class PlanSummary:
+    """Concise summary of a terraform plan."""
+
+    creates: int = 0
+    updates: int = 0
+    deletes: int = 0
+    replaces: int = 0
+    no_ops: int = 0
+
+    @property
+    def total_changes(self) -> int:
+        return self.creates + self.updates + self.deletes + self.replaces
+
+    @property
+    def is_empty(self) -> bool:
+        return self.total_changes == 0
+
+
+@dataclass
+class IdempotencyResult:
+    """Result of a post-apply idempotency check."""
+
+    status: Literal["pass", "fail", "error"]
+    unexpected_changes: int = 0
+    details: list[dict] = field(default_factory=list)
+    error_message: str = ""
+
+
+@dataclass
+class DeployResult:
+    """Structured output from deploying a single example."""
+
+    example: str
+    status: Literal["success", "failure", "timeout", "skipped"]
+    resources_created: int = 0
+    apply_duration_seconds: float = 0.0
+    idempotency: IdempotencyResult | None = None
+    plan_summary: PlanSummary | None = None
+    plan_json_path: str = ""
+    errors: list[str] = field(default_factory=list)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+@dataclass
+class AnalysisFinding:
+    """A single finding from the analysis phase."""
+
+    category: Literal["breaking_change", "idempotency", "missing_doc", "suggestion"]
+    severity: Literal["critical", "warning", "info"]
+    description: str
+    evidence: dict = field(default_factory=dict)
+    upgrade_md_reference: str | None = None
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+@dataclass
+class ReviewedFinding:
+    """A finding after cross-check by the reviewer."""
+
+    finding: AnalysisFinding
+    verdict: Literal["confirmed", "rejected", "needs_investigation"]
+    reviewer_notes: str = ""
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)
+
+
+@dataclass
+class TestReport:
+    """Complete test report for a module test run."""
+
+    module_source: str
+    module_version: str = ""
+    deploy_results: list[DeployResult] = field(default_factory=list)
+    findings: list[AnalysisFinding] = field(default_factory=list)
+    reviewed_findings: list[ReviewedFinding] = field(default_factory=list)
+
+    @property
+    def has_failures(self) -> bool:
+        return any(r.status == "failure" for r in self.deploy_results)
+
+    @property
+    def has_breaking_changes(self) -> bool:
+        return any(f.category == "breaking_change" for f in self.findings)
+
+    def to_json(self) -> str:
+        return json.dumps(asdict(self), indent=2)

--- a/tools/github_ops.py
+++ b/tools/github_ops.py
@@ -1,0 +1,189 @@
+"""GitHub operations tools using the gh CLI.
+
+Thin wrappers around the GitHub CLI for filing issues, creating PRs,
+and posting test results.  These serve as the local-dev fallback when
+the GitHub MCP server is not available (Foundry-hosted mode uses MCP).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+
+def _gh(args: list[str], timeout: int = 60) -> dict:
+    """Run a gh CLI command and return structured output."""
+    cmd = ["gh"] + args
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        stdout = result.stdout[-8000:] if len(result.stdout) > 8000 else result.stdout
+        stderr = result.stderr[-4000:] if len(result.stderr) > 4000 else result.stderr
+        return {"exit_code": result.returncode, "stdout": stdout, "stderr": stderr}
+    except subprocess.TimeoutExpired:
+        return {"exit_code": -1, "stdout": "", "stderr": f"gh command timed out after {timeout}s"}
+    except FileNotFoundError:
+        return {"exit_code": -1, "stdout": "", "stderr": "gh CLI not found — install from https://cli.github.com/"}
+
+
+from agent_framework import ai_function
+
+
+@ai_function
+def create_github_issue(
+    repo: str,
+    title: str,
+    body: str,
+    labels: str = "",
+) -> str:
+    """Create a GitHub issue to report a finding from module testing.
+
+    Args:
+        repo: Repository in owner/repo format (e.g. 'Azure/terraform-azurerm-avm-res-network-applicationgateway').
+        title: Issue title.
+        body: Issue body in markdown format.
+        labels: Comma-separated labels (e.g. 'bug,avm-testing').
+
+    Returns:
+        JSON with the created issue URL or error.
+    """
+    cmd = ["issue", "create", "--repo", repo, "--title", title, "--body", body]
+    if labels:
+        cmd.extend(["--label", labels])
+    result = _gh(cmd)
+    if result["exit_code"] == 0:
+        issue_url = result["stdout"].strip()
+        return json.dumps({"status": "created", "url": issue_url})
+    return json.dumps({"status": "error", "details": result})
+
+
+@ai_function
+def create_pull_request(
+    repo: str,
+    branch: str,
+    title: str,
+    body: str,
+    base: str = "main",
+    draft: bool = True,
+) -> str:
+    """Create a pull request to propose changes to a module.
+
+    Args:
+        repo: Repository in owner/repo format.
+        branch: Head branch with the changes.
+        title: PR title.
+        body: PR description in markdown.
+        base: Base branch to merge into (default 'main').
+        draft: Whether to create as draft PR (default True).
+
+    Returns:
+        JSON with the created PR URL or error.
+    """
+    cmd = [
+        "pr", "create",
+        "--repo", repo,
+        "--head", branch,
+        "--base", base,
+        "--title", title,
+        "--body", body,
+    ]
+    if draft:
+        cmd.append("--draft")
+    result = _gh(cmd)
+    if result["exit_code"] == 0:
+        pr_url = result["stdout"].strip()
+        return json.dumps({"status": "created", "url": pr_url})
+    return json.dumps({"status": "error", "details": result})
+
+
+@ai_function
+def add_issue_comment(
+    repo: str,
+    issue_number: int,
+    comment: str,
+) -> str:
+    """Add a comment to an existing GitHub issue or PR.
+
+    Use this to post test results back to a tracking issue.
+
+    Args:
+        repo: Repository in owner/repo format.
+        issue_number: Issue or PR number.
+        comment: Comment body in markdown.
+
+    Returns:
+        JSON with the comment URL or error.
+    """
+    cmd = [
+        "issue", "comment",
+        "--repo", repo,
+        str(issue_number),
+        "--body", comment,
+    ]
+    result = _gh(cmd)
+    if result["exit_code"] == 0:
+        return json.dumps({"status": "commented", "issue": issue_number})
+    return json.dumps({"status": "error", "details": result})
+
+
+@ai_function
+def search_github_issues(
+    repo: str,
+    query: str,
+    limit: int = 10,
+) -> str:
+    """Search GitHub issues in a repository.
+
+    Use this to find existing issues before filing duplicates.
+
+    Args:
+        repo: Repository in owner/repo format.
+        query: Search query string.
+        limit: Maximum results to return.
+
+    Returns:
+        JSON array of matching issues with number, title, state, and URL.
+    """
+    cmd = [
+        "issue", "list",
+        "--repo", repo,
+        "--search", query,
+        "--limit", str(limit),
+        "--json", "number,title,state,url,labels",
+    ]
+    result = _gh(cmd)
+    if result["exit_code"] == 0:
+        try:
+            issues = json.loads(result["stdout"])
+            return json.dumps(issues, indent=2)
+        except json.JSONDecodeError:
+            return json.dumps({"status": "error", "details": "Failed to parse gh output"})
+    return json.dumps({"status": "error", "details": result})
+
+
+@ai_function
+def get_latest_release(
+    repo: str,
+) -> str:
+    """Get the latest release version for a repository.
+
+    Useful for determining the current published version of a module.
+
+    Args:
+        repo: Repository in owner/repo format.
+
+    Returns:
+        JSON with tag name, title, and published date.
+    """
+    cmd = [
+        "release", "view",
+        "--repo", repo,
+        "--json", "tagName,name,publishedAt",
+    ]
+    result = _gh(cmd)
+    if result["exit_code"] == 0:
+        try:
+            release = json.loads(result["stdout"])
+            return json.dumps(release)
+        except json.JSONDecodeError:
+            return json.dumps({"status": "error", "details": "Failed to parse release info"})
+    return json.dumps({"status": "error", "details": result})

--- a/tools/github_ops.py
+++ b/tools/github_ops.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import json
 import subprocess
 
+from agent_framework import ai_function
+
 
 def _gh(args: list[str], timeout: int = 60) -> dict:
     """Run a gh CLI command and return structured output."""
@@ -23,9 +25,6 @@ def _gh(args: list[str], timeout: int = 60) -> dict:
         return {"exit_code": -1, "stdout": "", "stderr": f"gh command timed out after {timeout}s"}
     except FileNotFoundError:
         return {"exit_code": -1, "stdout": "", "stderr": "gh CLI not found — install from https://cli.github.com/"}
-
-
-from agent_framework import ai_function
 
 
 @ai_function

--- a/tools/module_discovery.py
+++ b/tools/module_discovery.py
@@ -16,7 +16,7 @@ from pathlib import Path
 from agent_framework import ai_function
 
 from models import ModuleMap
-from tools.terraform import _run, _workspace_path
+from tools.terraform import _workspace_path
 
 
 def _scan_examples(module_root: Path) -> list[str]:
@@ -41,7 +41,10 @@ def _scan_tests(module_root: Path) -> dict[str, list[str]]:
             continue
         files = sorted(
             f.name for f in category_dir.iterdir()
-            if f.is_file() and f.suffix in (".tf", ".tftest.hcl", ".go")
+            if f.is_file() and (
+                f.suffix in (".tf", ".go")
+                or f.name.endswith(".tftest.hcl")
+            )
         )
         if files:
             tests[category_dir.name] = files

--- a/tools/module_discovery.py
+++ b/tools/module_discovery.py
@@ -1,0 +1,280 @@
+"""Module discovery and ingestion tools.
+
+Scans a Module Under Test (MUT) to build a structured ModuleMap —
+the agent uses this to understand what examples, tests, skills,
+and tooling are available before starting a test run.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+from pathlib import Path
+
+from agent_framework import ai_function
+
+from models import ModuleMap
+from tools.terraform import _run, _workspace_path
+
+
+def _scan_examples(module_root: Path) -> list[str]:
+    """Return sorted list of example directory names."""
+    examples_dir = module_root / "examples"
+    if not examples_dir.is_dir():
+        return []
+    return sorted(
+        d.name for d in examples_dir.iterdir()
+        if d.is_dir() and not d.name.startswith(".")
+    )
+
+
+def _scan_tests(module_root: Path) -> dict[str, list[str]]:
+    """Return test files grouped by category (unit, integration, e2e)."""
+    tests: dict[str, list[str]] = {}
+    tests_dir = module_root / "tests"
+    if not tests_dir.is_dir():
+        return tests
+    for category_dir in sorted(tests_dir.iterdir()):
+        if not category_dir.is_dir() or category_dir.name.startswith("."):
+            continue
+        files = sorted(
+            f.name for f in category_dir.iterdir()
+            if f.is_file() and f.suffix in (".tf", ".tftest.hcl", ".go")
+        )
+        if files:
+            tests[category_dir.name] = files
+    return tests
+
+
+def _scan_skills(module_root: Path) -> list[str]:
+    """Return relative paths to skill markdown files."""
+    skills: list[str] = []
+    agents_dir = module_root / ".agents"
+    if not agents_dir.is_dir():
+        return skills
+    for md_file in sorted(agents_dir.rglob("*.md")):
+        skills.append(str(md_file.relative_to(module_root)))
+    return skills
+
+
+def _parse_providers(module_root: Path) -> dict[str, str]:
+    """Extract provider version constraints from terraform.tf or versions.tf."""
+    providers: dict[str, str] = {}
+    for tf_file in ["terraform.tf", "versions.tf"]:
+        path = module_root / tf_file
+        if not path.is_file():
+            continue
+        content = path.read_text()
+        # Match: source = "hashicorp/azurerm" and version = "~> 3.0"
+        blocks = re.findall(
+            r'(\w+)\s*=\s*\{[^}]*source\s*=\s*"([^"]+)"[^}]*version\s*=\s*"([^"]+)"',
+            content,
+            re.DOTALL,
+        )
+        for name, source, version in blocks:
+            providers[source] = version
+    return providers
+
+
+def _detect_devcontainer_image(module_root: Path) -> str | None:
+    """Read devcontainer.json for the container image."""
+    dc_path = module_root / ".devcontainer" / "devcontainer.json"
+    if not dc_path.is_file():
+        return None
+    try:
+        # devcontainer.json may have comments — strip them
+        content = dc_path.read_text()
+        lines = [l for l in content.splitlines() if not l.strip().startswith("//")]
+        data = json.loads("\n".join(lines))
+        return data.get("image") or data.get("build", {}).get("dockerfile")
+    except (json.JSONDecodeError, KeyError):
+        return None
+
+
+@ai_function
+def ingest_local_module(
+    workspace_id: str,
+    local_path: str,
+    target_dir: str = "module",
+) -> str:
+    """Ingest a Terraform module from a local filesystem path into a workspace.
+
+    Creates a symlink (or copies if symlink fails) from the local module
+    path into the workspace.  Use this for modules already checked out
+    on the local machine.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        local_path: Absolute path to the module directory on disk.
+        target_dir: Directory name within the workspace.
+
+    Returns:
+        JSON with ingestion result including the workspace-relative path.
+    """
+    source = Path(local_path).expanduser().resolve()
+    if not source.is_dir():
+        return json.dumps({"error": f"Local path not found or not a directory: {local_path}"})
+
+    ws_path = _workspace_path(workspace_id)
+    target = ws_path / target_dir
+
+    if target.exists():
+        return json.dumps({"error": f"Target directory already exists: {target_dir}"})
+
+    try:
+        # Prefer symlink for speed; fall back to copy
+        os.symlink(source, target)
+        method = "symlink"
+    except OSError:
+        shutil.copytree(source, target, dirs_exist_ok=True)
+        method = "copy"
+
+    return json.dumps({
+        "status": "ingested",
+        "source": str(source),
+        "target": target_dir,
+        "method": method,
+        "workspace_id": workspace_id,
+    })
+
+
+@ai_function
+def discover_module_structure(
+    workspace_id: str,
+    module_dir: str = "module",
+) -> str:
+    """Scan a module in the workspace and return its structure as a ModuleMap.
+
+    Discovers examples, tests, skill files, UPGRADE.md, AVM CLI
+    availability, provider requirements, and devcontainer configuration.
+    Call this after cloning or ingesting a module.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        module_dir: Directory within the workspace containing the module.
+
+    Returns:
+        JSON ModuleMap with all discovered module components.
+    """
+    module_root = _workspace_path(workspace_id) / module_dir
+    if not module_root.is_dir():
+        return json.dumps({"error": f"Module directory not found: {module_dir}"})
+
+    # Determine source type from how the module was ingested
+    if module_root.is_symlink():
+        source_type = "local"
+    elif (module_root / ".git").exists():
+        source_type = "git"
+    else:
+        source_type = "local"
+
+    module_map = ModuleMap(
+        source_path=str(module_root.resolve()),
+        source_type=source_type,
+        examples=_scan_examples(module_root),
+        tests=_scan_tests(module_root),
+        skills=_scan_skills(module_root),
+        upgrade_md="UPGRADE.md" if (module_root / "UPGRADE.md").is_file() else None,
+        avm_cli=(module_root / "avm").is_file() and os.access(module_root / "avm", os.X_OK),
+        providers=_parse_providers(module_root),
+        devcontainer_image=_detect_devcontainer_image(module_root),
+    )
+
+    return module_map.to_json()
+
+
+@ai_function
+def read_module_skill(
+    workspace_id: str,
+    skill_path: str,
+    module_dir: str = "module",
+) -> str:
+    """Read a skill file from the Module Under Test.
+
+    Skills are markdown files in the MUT's .agents/skills/ directory that
+    provide domain knowledge (AzAPI patterns, test conventions, etc.).
+    The agent reads these at runtime instead of embedding its own copy.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        skill_path: Relative path within the module (e.g. '.agents/skills/.../AzAPI.md').
+        module_dir: Directory within the workspace containing the module.
+
+    Returns:
+        JSON with the skill file content.
+    """
+    module_root = _workspace_path(workspace_id) / module_dir
+    full_path = module_root / skill_path
+
+    # Prevent path traversal outside module
+    try:
+        full_path.resolve().relative_to(module_root.resolve())
+    except ValueError:
+        return json.dumps({"error": "Path traversal not allowed"})
+
+    if not full_path.is_file():
+        return json.dumps({"error": f"Skill file not found: {skill_path}"})
+
+    try:
+        content = full_path.read_text()
+        if len(content) > 20000:
+            content = content[:20000] + "\n\n[... truncated ...]"
+        return json.dumps({
+            "skill_path": skill_path,
+            "content": content,
+            "size_bytes": full_path.stat().st_size,
+        })
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
+@ai_function
+def list_module_examples(
+    workspace_id: str,
+    module_dir: str = "module",
+) -> str:
+    """List all examples in a module with their descriptions.
+
+    Scans each example directory for a README.md to extract the
+    description, and checks for .tfvars files.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        module_dir: Directory within the workspace containing the module.
+
+    Returns:
+        JSON array of examples with name, description, and tfvars files.
+    """
+    module_root = _workspace_path(workspace_id) / module_dir
+    examples_dir = module_root / "examples"
+    if not examples_dir.is_dir():
+        return json.dumps({"error": "No examples directory found", "examples": []})
+
+    examples = []
+    for ex_dir in sorted(examples_dir.iterdir()):
+        if not ex_dir.is_dir() or ex_dir.name.startswith("."):
+            continue
+
+        entry: dict = {"name": ex_dir.name}
+
+        # Extract description from README
+        readme = ex_dir / "README.md"
+        if readme.is_file():
+            lines = readme.read_text().splitlines()[:5]
+            desc = next((l.lstrip("# ").strip() for l in lines if l.strip()), "")
+            entry["description"] = desc
+
+        # List tfvars files
+        tfvars = [f.name for f in ex_dir.iterdir() if f.suffix in (".tfvars", ".auto.tfvars")]
+        if tfvars:
+            entry["tfvars_files"] = tfvars
+
+        # List .tf files
+        tf_files = [f.name for f in ex_dir.iterdir() if f.suffix == ".tf"]
+        entry["tf_files"] = tf_files
+
+        examples.append(entry)
+
+    return json.dumps(examples, indent=2)

--- a/tools/reporting.py
+++ b/tools/reporting.py
@@ -1,0 +1,289 @@
+"""Reporting tools for generating structured test reports and GitHub content.
+
+These tools format findings from the analysis phase into actionable
+outputs — test reports, issue bodies, and UPGRADE.md suggestions.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from agent_framework import ai_function
+
+from tools.terraform import _workspace_path
+
+
+@ai_function
+def generate_test_report(
+    workspace_id: str,
+    module_source: str,
+    module_version: str = "",
+    deploy_results_json: str = "[]",
+    findings_json: str = "[]",
+) -> str:
+    """Generate a structured markdown test report.
+
+    Produces a report summarising which examples were tested, deploy
+    outcomes, idempotency results, and findings from plan diff analysis.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        module_source: Module source identifier (registry path or local path).
+        module_version: Version tested (if applicable).
+        deploy_results_json: JSON array of deploy result objects.
+        findings_json: JSON array of analysis finding objects.
+
+    Returns:
+        JSON with the markdown report and a summary object.
+    """
+    try:
+        deploy_results = json.loads(deploy_results_json)
+        findings = json.loads(findings_json)
+    except json.JSONDecodeError as e:
+        return json.dumps({"error": f"Invalid JSON input: {e}"})
+
+    timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+    lines = [
+        f"# Module Test Report",
+        f"",
+        f"**Module:** `{module_source}`",
+        f"**Version:** {module_version or 'N/A'}",
+        f"**Date:** {timestamp}",
+        f"**Workspace:** `{workspace_id}`",
+        f"",
+    ]
+
+    # Deploy results table
+    if deploy_results:
+        lines.extend([
+            "## Deploy Results",
+            "",
+            "| Example | Status | Resources | Idempotency | Errors |",
+            "|---------|--------|-----------|-------------|--------|",
+        ])
+        for r in deploy_results:
+            idemp = r.get("idempotency", {})
+            idemp_status = idemp.get("status", "n/a") if idemp else "n/a"
+            errors = "; ".join(r.get("errors", [])) or "—"
+            lines.append(
+                f"| {r.get('example', '?')} "
+                f"| {_status_icon(r.get('status', '?'))} {r.get('status', '?')} "
+                f"| {r.get('resources_created', 0)} "
+                f"| {_status_icon(idemp_status)} {idemp_status} "
+                f"| {errors} |"
+            )
+        lines.append("")
+
+    # Findings
+    if findings:
+        lines.extend(["## Findings", ""])
+        for i, f in enumerate(findings, 1):
+            severity = f.get("severity", "info")
+            icon = {"critical": "🔴", "warning": "🟡", "info": "🔵"}.get(severity, "⚪")
+            lines.extend([
+                f"### {icon} Finding {i}: {f.get('category', 'unknown')} ({severity})",
+                "",
+                f"{f.get('description', 'No description')}",
+                "",
+            ])
+            if f.get("upgrade_md_reference"):
+                lines.append(f"> **UPGRADE.md reference:** {f['upgrade_md_reference']}")
+                lines.append("")
+
+    # Summary
+    total_deploys = len(deploy_results)
+    successes = sum(1 for r in deploy_results if r.get("status") == "success")
+    failures = sum(1 for r in deploy_results if r.get("status") == "failure")
+    idemp_fails = sum(
+        1 for r in deploy_results
+        if r.get("idempotency", {}).get("status") == "fail"
+    )
+    critical_findings = sum(1 for f in findings if f.get("severity") == "critical")
+
+    lines.extend([
+        "## Summary",
+        "",
+        f"- **Deploys:** {successes}/{total_deploys} succeeded",
+        f"- **Failures:** {failures}",
+        f"- **Idempotency failures:** {idemp_fails}",
+        f"- **Critical findings:** {critical_findings}",
+        f"- **Total findings:** {len(findings)}",
+    ])
+
+    report_md = "\n".join(lines)
+
+    # Save report to workspace
+    report_path = _workspace_path(workspace_id) / "test-report.md"
+    report_path.write_text(report_md)
+
+    return json.dumps({
+        "report": report_md,
+        "report_path": "test-report.md",
+        "summary": {
+            "total_deploys": total_deploys,
+            "successes": successes,
+            "failures": failures,
+            "idempotency_failures": idemp_fails,
+            "critical_findings": critical_findings,
+            "total_findings": len(findings),
+        },
+    })
+
+
+@ai_function
+def generate_issue_body(
+    finding_category: str,
+    finding_description: str,
+    module_source: str,
+    module_version: str = "",
+    evidence_json: str = "{}",
+) -> str:
+    """Format a finding as a GitHub issue body ready for filing.
+
+    Args:
+        finding_category: Category (breaking_change, idempotency, missing_doc, suggestion).
+        finding_description: Description of the finding.
+        module_source: Module source identifier.
+        module_version: Version where the issue was found.
+        evidence_json: JSON object with supporting evidence.
+
+    Returns:
+        JSON with the formatted issue title and body.
+    """
+    try:
+        evidence = json.loads(evidence_json)
+    except json.JSONDecodeError:
+        evidence = {}
+
+    category_labels = {
+        "breaking_change": ("Breaking Change", "bug"),
+        "idempotency": ("Idempotency Issue", "bug"),
+        "missing_doc": ("Missing Documentation", "documentation"),
+        "suggestion": ("Improvement Suggestion", "enhancement"),
+    }
+    label_info = category_labels.get(finding_category, (finding_category, "bug"))
+
+    title = f"[AVM Testing] {label_info[0]}: {finding_description[:80]}"
+    body_lines = [
+        f"## {label_info[0]}",
+        "",
+        f"**Module:** `{module_source}`",
+        f"**Version:** {module_version or 'N/A'}",
+        f"**Detected by:** AVM Module Testing Agent",
+        "",
+        "### Description",
+        "",
+        finding_description,
+        "",
+    ]
+
+    if evidence:
+        body_lines.extend([
+            "### Evidence",
+            "",
+            "```json",
+            json.dumps(evidence, indent=2),
+            "```",
+            "",
+        ])
+
+    body_lines.extend([
+        "### Reproduction",
+        "",
+        f"1. Clone the module at version `{module_version or 'latest'}`",
+        "2. Run `terraform init` in the affected example",
+        "3. Run `terraform apply`",
+        "4. Observe the issue described above",
+        "",
+        "---",
+        "*This issue was automatically filed by the AVM Module Testing Agent.*",
+    ])
+
+    return json.dumps({
+        "title": title,
+        "body": "\n".join(body_lines),
+        "suggested_labels": label_info[1],
+    })
+
+
+@ai_function
+def generate_upgrade_doc_suggestion(
+    observed_changes_json: str,
+    existing_upgrade_md: str = "",
+    module_version_from: str = "",
+    module_version_to: str = "",
+) -> str:
+    """Propose UPGRADE.md additions based on observed plan diffs.
+
+    Compares observed terraform plan changes against existing UPGRADE.md
+    content and suggests additions for undocumented breaking changes.
+
+    Args:
+        observed_changes_json: JSON array of resource changes from plan diff.
+        existing_upgrade_md: Current UPGRADE.md content (empty if none exists).
+        module_version_from: Version being upgraded from.
+        module_version_to: Version being upgraded to.
+
+    Returns:
+        JSON with suggested UPGRADE.md additions and matched/unmatched changes.
+    """
+    try:
+        changes = json.loads(observed_changes_json)
+    except json.JSONDecodeError:
+        return json.dumps({"error": "Invalid observed_changes_json"})
+
+    # Categorise changes
+    breaking = [c for c in changes if c.get("actions") in [["delete", "create"], ["create", "delete"]]]
+    updates = [c for c in changes if c.get("actions") == ["update"]]
+    deletes = [c for c in changes if c.get("actions") == ["delete"]]
+
+    # Check which changes are documented
+    documented = []
+    undocumented = []
+    for change in breaking + deletes:
+        addr = change.get("address", "")
+        resource_type = change.get("type", "")
+        if existing_upgrade_md and (addr in existing_upgrade_md or resource_type in existing_upgrade_md):
+            documented.append(change)
+        else:
+            undocumented.append(change)
+
+    # Generate suggestion
+    suggestion_lines = []
+    if undocumented:
+        version_header = f"{module_version_from} → {module_version_to}" if module_version_from else "Latest"
+        suggestion_lines.extend([
+            f"## Upgrade from {version_header}",
+            "",
+            "### Breaking Changes",
+            "",
+        ])
+        for change in undocumented:
+            suggestion_lines.append(
+                f"- `{change.get('address', '?')}` — action: {change.get('actions', '?')}"
+            )
+        suggestion_lines.append("")
+
+    return json.dumps({
+        "has_suggestions": len(undocumented) > 0,
+        "documented_changes": len(documented),
+        "undocumented_changes": len(undocumented),
+        "suggestion_md": "\n".join(suggestion_lines) if suggestion_lines else "",
+        "breaking_changes": len(breaking),
+        "updates": len(updates),
+        "deletes": len(deletes),
+    }, indent=2)
+
+
+def _status_icon(status: str) -> str:
+    """Return an emoji icon for a status value."""
+    return {
+        "success": "✅",
+        "failure": "❌",
+        "timeout": "⏱️",
+        "skipped": "⏭️",
+        "pass": "✅",
+        "fail": "❌",
+        "error": "⚠️",
+    }.get(status, "⚪")

--- a/tools/terraform.py
+++ b/tools/terraform.py
@@ -269,6 +269,227 @@ def terraform_test(
 
 
 @ai_function
+def terraform_init_upgrade(
+    workspace_id: str,
+    working_dir: str = ".",
+    backend_config: str = "",
+) -> str:
+    """Run ``terraform init -upgrade`` inside a workspace.
+
+    This variant uses the ``-upgrade`` flag to update provider and module
+    versions, which is required when testing module upgrades or when AVM
+    examples pin minimum versions.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        working_dir: Relative path within the workspace to the root module.
+        backend_config: Optional JSON object of backend config overrides.
+
+    Returns:
+        JSON with exit_code, stdout, stderr.
+    """
+    ws_path = _workspace_path(workspace_id) / working_dir
+    cmd = ["terraform", "init", "-upgrade", "-input=false", "-no-color"]
+    if backend_config:
+        try:
+            pairs = json.loads(backend_config)
+            for k, v in pairs.items():
+                cmd.append(f"-backend-config={k}={v}")
+        except json.JSONDecodeError:
+            return json.dumps({"error": "backend_config must be valid JSON"})
+    return json.dumps(_run(cmd, ws_path))
+
+
+@ai_function
+def run_avm_cli(
+    workspace_id: str,
+    command: str,
+    module_dir: str = "module",
+) -> str:
+    """Run the AVM CLI tool (``./avm``) from a module workspace.
+
+    The AVM template ships an ``avm`` script that wraps common operations
+    like pre-commit checks, PR validation, unit tests, and integration tests.
+    The agent reads this from the MUT rather than embedding its own copy.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        command: AVM CLI command to run (e.g. 'pre-commit', 'tf-test-unit').
+        module_dir: Directory within the workspace containing the module.
+
+    Returns:
+        JSON with exit_code, stdout, stderr.
+    """
+    allowed_commands = {
+        "pre-commit", "pr-check", "tf-test-unit",
+        "tf-test-integration", "tf-test-example", "version",
+    }
+    if command not in allowed_commands:
+        return json.dumps({
+            "error": f"Command '{command}' not allowed. Allowed: {sorted(allowed_commands)}",
+        })
+
+    ws_path = _workspace_path(workspace_id) / module_dir
+    avm_path = ws_path / "avm"
+    if not avm_path.is_file():
+        return json.dumps({"error": "AVM CLI not found in module directory"})
+
+    cmd = [str(avm_path), command]
+    return json.dumps(_run(cmd, ws_path, timeout=1800))
+
+
+@ai_function
+def terraform_plan_json(
+    workspace_id: str,
+    working_dir: str = ".",
+    var_file: str = "",
+    out_file: str = "tfplan",
+) -> str:
+    """Run ``terraform plan``, save the plan, and return a structured JSON summary.
+
+    Combines plan + show in one call to produce structured output suitable
+    for passing to the analysis phase without raw terraform output in context.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        working_dir: Relative path within the workspace to the root module.
+        var_file: Optional path (relative to working_dir) to a .tfvars file.
+        out_file: Name for the saved plan file.
+
+    Returns:
+        JSON with plan_summary (creates/updates/deletes/replaces counts)
+        and resource_changes list, or error details.
+    """
+    ws_path = _workspace_path(workspace_id) / working_dir
+
+    # Run plan
+    plan_cmd = ["terraform", "plan", "-input=false", "-no-color", f"-out={out_file}"]
+    if var_file:
+        plan_cmd.append(f"-var-file={var_file}")
+    plan_result = _run(plan_cmd, ws_path)
+
+    if plan_result["exit_code"] != 0:
+        return json.dumps({"status": "error", "phase": "plan", "details": plan_result})
+
+    # Convert to JSON
+    show_cmd = ["terraform", "show", "-json", "-no-color", out_file]
+    show_result = _run(show_cmd, ws_path, timeout=60)
+
+    if show_result["exit_code"] != 0:
+        return json.dumps({"status": "error", "phase": "show", "details": show_result})
+
+    try:
+        plan_data = json.loads(show_result["stdout"])
+    except json.JSONDecodeError:
+        return json.dumps({"status": "error", "phase": "parse", "details": "Failed to parse plan JSON"})
+
+    # Build structured summary
+    changes = plan_data.get("resource_changes", [])
+    summary = {"creates": 0, "updates": 0, "deletes": 0, "replaces": 0, "no_ops": 0}
+    resource_changes = []
+
+    for rc in changes:
+        actions = rc.get("change", {}).get("actions", [])
+        addr = rc.get("address", "unknown")
+        entry = {"address": addr, "type": rc.get("type", ""), "actions": actions}
+
+        if actions == ["no-op"] or actions == ["read"]:
+            summary["no_ops"] += 1
+        elif actions == ["create"]:
+            summary["creates"] += 1
+            resource_changes.append(entry)
+        elif actions == ["delete"]:
+            summary["deletes"] += 1
+            resource_changes.append(entry)
+        elif actions == ["update"]:
+            summary["updates"] += 1
+            resource_changes.append(entry)
+        elif "delete" in actions and "create" in actions:
+            summary["replaces"] += 1
+            resource_changes.append(entry)
+        else:
+            resource_changes.append(entry)
+
+    return json.dumps({
+        "status": "success",
+        "plan_file": out_file,
+        "summary": summary,
+        "total_changes": summary["creates"] + summary["updates"] + summary["deletes"] + summary["replaces"],
+        "resource_changes": resource_changes,
+    }, indent=2)
+
+
+@ai_function
+def check_idempotency(
+    workspace_id: str,
+    working_dir: str = ".",
+    var_file: str = "",
+) -> str:
+    """Run a terraform plan after apply to check idempotency.
+
+    A well-written module should produce an empty plan after apply.
+    Any unexpected changes indicate an idempotency issue.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        working_dir: Relative path within the workspace to the root module.
+        var_file: Optional .tfvars file.
+
+    Returns:
+        JSON with idempotency status (pass/fail), unexpected change count,
+        and details of any non-empty plan resources.
+    """
+    ws_path = _workspace_path(workspace_id) / working_dir
+    plan_cmd = ["terraform", "plan", "-input=false", "-no-color", "-detailed-exitcode", "-out=idempotency-check"]
+    if var_file:
+        plan_cmd.append(f"-var-file={var_file}")
+
+    result = _run(plan_cmd, ws_path)
+
+    # Exit code 0 = empty plan (pass), 2 = changes detected (fail), other = error
+    if result["exit_code"] == 0:
+        return json.dumps({
+            "status": "pass",
+            "unexpected_changes": 0,
+            "details": [],
+            "message": "Idempotency check passed — no changes detected after apply.",
+        })
+    elif result["exit_code"] == 2:
+        # Parse the plan to get details of unexpected changes
+        show_cmd = ["terraform", "show", "-json", "-no-color", "idempotency-check"]
+        show_result = _run(show_cmd, ws_path, timeout=60)
+
+        details = []
+        if show_result["exit_code"] == 0:
+            try:
+                plan_data = json.loads(show_result["stdout"])
+                for rc in plan_data.get("resource_changes", []):
+                    actions = rc.get("change", {}).get("actions", [])
+                    if actions not in [["no-op"], ["read"]]:
+                        details.append({
+                            "address": rc.get("address", "unknown"),
+                            "actions": actions,
+                            "type": rc.get("type", ""),
+                        })
+            except json.JSONDecodeError:
+                pass
+
+        return json.dumps({
+            "status": "fail",
+            "unexpected_changes": len(details),
+            "details": details,
+            "message": f"Idempotency check FAILED — {len(details)} unexpected change(s) detected.",
+        })
+    else:
+        return json.dumps({
+            "status": "error",
+            "unexpected_changes": 0,
+            "details": [],
+            "message": f"Idempotency check error: {result['stderr'][-500:]}",
+        })
+
+
+@ai_function
 def list_workspace_files(
     workspace_id: str,
     relative_path: str = ".",

--- a/tools/terraform.py
+++ b/tools/terraform.py
@@ -121,10 +121,12 @@ def terraform_init(
     if backend_config:
         try:
             pairs = json.loads(backend_config)
-            for k, v in pairs.items():
-                cmd.append(f"-backend-config={k}={v}")
         except json.JSONDecodeError:
             return json.dumps({"error": "backend_config must be valid JSON"})
+        if not isinstance(pairs, dict):
+            return json.dumps({"error": "backend_config must be a JSON object"})
+        for k, v in pairs.items():
+            cmd.append(f"-backend-config={k}={v}")
     return json.dumps(_run(cmd, ws_path))
 
 
@@ -293,10 +295,12 @@ def terraform_init_upgrade(
     if backend_config:
         try:
             pairs = json.loads(backend_config)
-            for k, v in pairs.items():
-                cmd.append(f"-backend-config={k}={v}")
         except json.JSONDecodeError:
             return json.dumps({"error": "backend_config must be valid JSON"})
+        if not isinstance(pairs, dict):
+            return json.dumps({"error": "backend_config must be a JSON object"})
+        for k, v in pairs.items():
+            cmd.append(f"-backend-config={k}={v}")
     return json.dumps(_run(cmd, ws_path))
 
 
@@ -333,6 +337,8 @@ def run_avm_cli(
     avm_path = ws_path / "avm"
     if not avm_path.is_file():
         return json.dumps({"error": "AVM CLI not found in module directory"})
+    if not os.access(avm_path, os.X_OK):
+        return json.dumps({"error": "AVM CLI exists but is not executable. Run: chmod +x ./avm"})
 
     cmd = [str(avm_path), command]
     return json.dumps(_run(cmd, ws_path, timeout=1800))
@@ -460,6 +466,7 @@ def check_idempotency(
         show_result = _run(show_cmd, ws_path, timeout=60)
 
         details = []
+        parse_failed = False
         if show_result["exit_code"] == 0:
             try:
                 plan_data = json.loads(show_result["stdout"])
@@ -472,13 +479,23 @@ def check_idempotency(
                             "type": rc.get("type", ""),
                         })
             except json.JSONDecodeError:
-                pass
+                parse_failed = True
+        else:
+            parse_failed = True
+
+        change_count = len(details) if not parse_failed else -1
+        message = (
+            f"Idempotency check FAILED — {len(details)} unexpected change(s) detected."
+            if not parse_failed
+            else "Idempotency check FAILED — changes detected but plan details could not be parsed."
+        )
 
         return json.dumps({
             "status": "fail",
-            "unexpected_changes": len(details),
+            "unexpected_changes": change_count,
             "details": details,
-            "message": f"Idempotency check FAILED — {len(details)} unexpected change(s) detected.",
+            "parse_failed": parse_failed,
+            "message": message,
         })
     else:
         return json.dumps({


### PR DESCRIPTION
## Summary

Implements work streams 1-5 of the enhanced testing agent architecture, adding structured module discovery, GitHub integration, test orchestration improvements, and reporting tools.

### Architecture

Three-layer separation: **MCP Servers → Testing Agent → Module Under Test (MUT)**

Core principle: **Read, Don't Duplicate** — the agent reads skills and domain knowledge from the MUT's `.agents/skills/` directory at runtime.

### New Files

- `models.py` — Shared data models for structured handoffs between agent phases
- `tools/module_discovery.py` — Ingest local modules, discover structure, read MUT skills
- `tools/github_ops.py` — Create issues/PRs, add comments, search issues (via gh CLI)
- `tools/reporting.py` — Generate test reports, issue bodies, UPGRADE.md suggestions

### Modified Files

- `tools/terraform.py` — Added terraform_init_upgrade, terraform_plan_json, check_idempotency, run_avm_cli
- `main.py` — Wire new tools, update system instructions
- `config.py` — MCP connection env vars, FOUNDRY_HOSTED flag
- `README.md` — Architecture overview, new tool groups
- `ROADMAP.md` — Three-layer architecture and multi-agent plan

### What's Next

- MCP server integration (MCPTool declarations)
- Dual runtime modes (runtime/local.py + runtime/foundry.py)
- Multi-agent extraction into agents/ directory