### PR TITLE
fix: address all 11 PR #3 review comments + rubber-duck escalations

### DIFF
--- a/.github/workflows/run-test.yml
+++ b/.github/workflows/run-test.yml
@@ -42,6 +42,11 @@ on:
         required: false
         default: "0"
         type: string
+      github_repo:
+        description: "GitHub repo (owner/repo) to post PR comments to (defaults to module_source)"
+        required: false
+        default: ""
+        type: string
       cleanup:
         description: "Destroy resources after testing"
         required: false
@@ -77,6 +82,10 @@ on:
       github_pr:
         required: false
         default: "0"
+        type: string
+      github_repo:
+        required: false
+        default: ""
         type: string
       cleanup:
         required: false
@@ -123,8 +132,8 @@ jobs:
         run: |
           MODULE_SOURCE="${{ inputs.module_source }}"
 
-          if [[ "$MODULE_SOURCE" == *"github.com"* ]] || [[ "$MODULE_SOURCE" == */* ]]; then
-            # Git-based source
+          if [[ "$MODULE_SOURCE" == *"github.com"* ]] || [[ "$MODULE_SOURCE" =~ ^[^/]+/[^/]+$ ]]; then
+            # Git-based source (GitHub URL or org/repo shorthand)
             REPO_URL="$MODULE_SOURCE"
             if [[ ! "$REPO_URL" == https://* ]]; then
               REPO_URL="https://github.com/${MODULE_SOURCE}.git"
@@ -196,8 +205,17 @@ jobs:
       - name: Clone module under test
         run: |
           MODULE_SOURCE="${{ inputs.module_source }}"
-          if [[ ! "$MODULE_SOURCE" == https://* ]]; then
-            MODULE_SOURCE="https://github.com/${MODULE_SOURCE}.git"
+          if [[ "$MODULE_SOURCE" == *"github.com"* ]] || [[ "$MODULE_SOURCE" =~ ^[^/]+/[^/]+$ ]]; then
+            # Git-based source (GitHub URL or org/repo shorthand)
+            if [[ ! "$MODULE_SOURCE" == https://* ]]; then
+              MODULE_SOURCE="https://github.com/${MODULE_SOURCE}.git"
+            fi
+          elif [[ "$MODULE_SOURCE" =~ ^[^/]+/[^/]+/[^/]+$ ]]; then
+            echo "Registry-based sources are not yet supported in GHA workflow"
+            exit 1
+          else
+            echo "Unsupported module_source format: $MODULE_SOURCE"
+            exit 1
           fi
           # Deep clone needed to switch between refs for upgrade testing
           git clone --depth 100 "$MODULE_SOURCE" module-under-test
@@ -440,6 +458,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           COMMENT_BODY=$(cat "$GITHUB_STEP_SUMMARY")
+          COMMENT_REPO="${{ inputs.github_repo || inputs.module_source }}"
           gh pr comment "${{ inputs.github_pr }}" \
-            --repo "${{ inputs.module_source }}" \
+            --repo "$COMMENT_REPO" \
             --body "$COMMENT_BODY" || echo "Could not post PR comment"

--- a/main.py
+++ b/main.py
@@ -55,6 +55,7 @@ from tools.azure import (
     get_current_identity,
 )
 from tools.git_ops import (
+    add_remote,
     clone_registry_module,
     clone_repo,
     git_switch_ref,
@@ -224,6 +225,8 @@ ALL_TOOLS = [
     # Git
     clone_repo,
     clone_registry_module,
+    git_switch_ref,
+    add_remote,
     # Module Discovery
     ingest_local_module,
     discover_module_structure,
@@ -238,10 +241,19 @@ ALL_TOOLS = [
     add_issue_comment,
     search_github_issues,
     get_latest_release,
+    download_workflow_artifacts,
+    get_workflow_run_status,
     # Reporting
     generate_test_report,
     generate_issue_body,
     generate_upgrade_doc_suggestion,
+    # Tracking
+    store_test_run,
+    query_findings,
+    query_module_health,
+    query_test_history,
+    # Upgrade Test
+    run_upgrade_test,
 ]
 
 
@@ -331,6 +343,12 @@ def main() -> None:
             logger.error("Policy check failed: %s", policy_result.reason)
             sys.exit(1)
         if policy_result.requires_confirmation:
+            if not test_request.interactive:
+                logger.error(
+                    "Policy requires confirmation but running in non-interactive (batch) mode: %s",
+                    policy_result.reason,
+                )
+                sys.exit(1)
             logger.warning("Policy: %s", policy_result.reason)
 
     # Format the initial message for batch mode

--- a/request.py
+++ b/request.py
@@ -37,6 +37,7 @@ class TestRequest:
     module_source: str = ""
     base_ref: str = "main"
     head_ref: str = ""
+    head_module_source: str = ""
 
     # Scope
     examples: list[str] = field(default_factory=list)
@@ -178,6 +179,9 @@ class TestRequest:
             )
         else:
             lines.append(f"**Ref**: {self.base_ref}")
+
+        if self.head_module_source:
+            lines.append(f"**Head module source**: {self.head_module_source}")
 
         if self.examples:
             lines.append(f"**Examples**: {', '.join(self.examples)}")

--- a/tools/git_ops.py
+++ b/tools/git_ops.py
@@ -68,8 +68,8 @@ def git_switch_ref(
                 "tag_fetch_result": tag_fetch,
             })
 
-    # Clean working tree before switching (remove untracked TF artifacts)
-    _git(["clean", "-fd"], ws_path)
+    # Clean working tree before switching (preserve external state files)
+    _git(["clean", "-fd", "--exclude=*.tfstate", "--exclude=*.tfstate.backup"], ws_path)
     _git(["checkout", "--", "."], ws_path)
 
     # Checkout detached to the fetched ref
@@ -180,3 +180,62 @@ def clone_registry_module(
 
     result["warning"] = f"Could not checkout version {version}, staying on default branch"
     return json.dumps(result)
+
+
+@ai_function
+def add_remote(
+    workspace_id: str,
+    remote_url: str,
+    remote_name: str = "upstream",
+    target_dir: str = "module",
+    fetch_depth: int = 50,
+) -> str:
+    """Add a second remote to an already-cloned repository and fetch it.
+
+    Useful for cross-repo upgrade testing where the base and head versions
+    live in different repositories.  After adding the remote, branches/tags
+    from it are available for ``git_switch_ref``.
+
+    Args:
+        workspace_id: Workspace id from create_workspace.
+        remote_url: HTTPS URL of the remote to add.
+        remote_name: Name for the new remote (default "upstream").
+        target_dir: Directory within the workspace containing the clone.
+        fetch_depth: How many commits to fetch (default 50, use 0 for full).
+
+    Returns:
+        JSON with the result of add + fetch.
+    """
+    if not remote_url.startswith("https://"):
+        return json.dumps({"error": "Only HTTPS remote URLs are accepted"})
+
+    ws_path = _workspace_path(workspace_id) / target_dir
+    if not (ws_path / ".git").exists():
+        return json.dumps({"error": f"No git repo found at {target_dir}"})
+
+    # Remove existing remote with same name if present (ignore errors)
+    _git(["remote", "remove", remote_name], ws_path)
+
+    add_result = _git(["remote", "add", remote_name, remote_url], ws_path)
+    if add_result["exit_code"] != 0:
+        return json.dumps({
+            "error": f"Failed to add remote: {add_result['stderr']}",
+            "result": add_result,
+        })
+
+    fetch_cmd = ["fetch", remote_name]
+    if fetch_depth > 0:
+        fetch_cmd.extend(["--depth", str(fetch_depth)])
+    fetch_result = _git(fetch_cmd, ws_path)
+    if fetch_result["exit_code"] != 0:
+        return json.dumps({
+            "error": f"Added remote but fetch failed: {fetch_result['stderr']}",
+            "remote_name": remote_name,
+            "fetch_result": fetch_result,
+        })
+
+    return json.dumps({
+        "status": "ready",
+        "remote_name": remote_name,
+        "remote_url": remote_url,
+    })

--- a/tools/github_ops.py
+++ b/tools/github_ops.py
@@ -306,7 +306,7 @@ def get_workflow_run_status(
     result = _gh(cmd)
     if result["exit_code"] == 0:
         try:
-            return result["stdout"]
+            return json.dumps(json.loads(result["stdout"]))
         except json.JSONDecodeError:
             return json.dumps({"status": "error", "details": "Failed to parse run info"})
     return json.dumps({"status": "error", "details": result})

--- a/tools/reporting.py
+++ b/tools/reporting.py
@@ -22,6 +22,7 @@ def generate_test_report(
     module_version: str = "",
     deploy_results_json: str = "[]",
     findings_json: str = "[]",
+    run_id: str = "",
 ) -> str:
     """Generate a structured markdown test report.
 
@@ -128,7 +129,7 @@ def generate_test_report(
     report_path.write_text(report_md)
 
     # Save structured JSON report to workspace
-    run_id = os.environ.get("RUN_ID", "")
+    run_id = run_id or os.environ.get("RUN_ID", "")
     json_report = {
         "run_id": run_id,
         "module_source": module_source,
@@ -148,6 +149,8 @@ def generate_test_report(
         "report_path": "test-report.md",
         "json_report_path": json_filename,
         "summary": summary,
+        "deploy_results": deploy_results,
+        "findings": findings,
     })
 
 

--- a/tools/tracking.py
+++ b/tools/tracking.py
@@ -13,9 +13,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
-from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any
 
 from agent_framework import ai_function

--- a/tools/upgrade_test.py
+++ b/tools/upgrade_test.py
@@ -31,7 +31,7 @@ from pathlib import Path
 
 from agent_framework import ai_function
 
-from tools.terraform import _run, _workspace_path
+from tools.terraform import _workspace_path
 
 
 def _tf_data_dir(ws_path: Path, example: str) -> Path:
@@ -43,6 +43,17 @@ def _tf_data_dir(ws_path: Path, example: str) -> Path:
     data_dir = ws_path / ".tf-data" / example.replace("/", "_")
     data_dir.mkdir(parents=True, exist_ok=True)
     return data_dir
+
+
+def _tf_state_path(ws_path: Path, example: str) -> Path:
+    """Return an external state file path for the given example.
+
+    Keeping terraform.tfstate outside the repo checkout prevents git clean
+    from deleting it when switching between refs.
+    """
+    state_dir = ws_path / ".tf-state" / example.replace("/", "_")
+    state_dir.mkdir(parents=True, exist_ok=True)
+    return state_dir / "terraform.tfstate"
 
 
 def _run_tf(
@@ -74,9 +85,11 @@ def _run_tf(
         return {"exit_code": -1, "stdout": "", "stderr": f"Command timed out after {timeout}s"}
 
 
-def _do_destroy(example_dir: Path, tf_data_dir: Path, var_file: str) -> dict:
+def _do_destroy(example_dir: Path, tf_data_dir: Path, var_file: str, state_path: Path | None = None) -> dict:
     """Run terraform destroy, best-effort."""
     cmd = ["terraform", "destroy", "-input=false", "-no-color", "-auto-approve"]
+    if state_path is not None:
+        cmd.append(f"-state={state_path}")
     if var_file:
         cmd.append(f"-var-file={var_file}")
     return _run_tf(cmd, example_dir, tf_data_dir, timeout=1200)
@@ -129,6 +142,7 @@ def run_upgrade_test(
     head_ref: str,
     var_file: str = "",
     cleanup: bool = True,
+    head_module_dir: str = "",
 ) -> str:
     """Run a full upgrade test for a single module example.
 
@@ -140,9 +154,9 @@ def run_upgrade_test(
     The tool does NOT apply the head version -- it only plans.  Analysis
     of the diff against UPGRADE.md is done by the analysis agent.
 
-    TF_DATA_DIR is set outside the repo tree so ref switching does not
-    contaminate provider state.  Cleanup (destroy) runs in a finally
-    block to prevent leaked infrastructure.
+    TF_DATA_DIR and terraform.tfstate are set outside the repo tree so
+    ref switching and git clean do not contaminate provider or state.
+    Cleanup (destroy) runs in a finally block to prevent leaked infrastructure.
 
     Args:
         workspace_id: Workspace id from create_workspace.
@@ -152,6 +166,10 @@ def run_upgrade_test(
         head_ref: The new version ref to upgrade to.
         var_file: Optional .tfvars file (relative to example dir).
         cleanup: Whether to destroy resources after testing (default true).
+        head_module_dir: Optional directory containing a separately-cloned
+            head version (for cross-repo upgrade testing).  When set, no git
+            ref switching is performed — base_module_dir is deployed, then
+            init -upgrade + plan run in head_module_dir.
 
     Returns:
         JSON UpgradeTestResult with base_deploy, base_idempotency,
@@ -160,8 +178,14 @@ def run_upgrade_test(
     from tools.git_ops import git_switch_ref
 
     ws_path = _workspace_path(workspace_id)
-    example_dir = ws_path / module_dir / "examples" / example
+    base_example_dir = ws_path / module_dir / "examples" / example
+    head_example_dir = (
+        ws_path / head_module_dir / "examples" / example
+        if head_module_dir
+        else base_example_dir
+    )
     tf_data_dir = _tf_data_dir(ws_path, example)
+    state_path = _tf_state_path(ws_path, example)
 
     result: dict = {
         "example": example,
@@ -179,19 +203,21 @@ def run_upgrade_test(
         "timing": {},
     }
 
+    deployed = False
     try:
-        # --- Phase 1: Switch to base_ref ---
-        t0 = time.time()
-        switch_base = json.loads(git_switch_ref(workspace_id, base_ref, module_dir))
-        if "error" in switch_base:
-            result["status"] = "failure"
-            result["errors"].append(f"Failed to checkout base_ref '{base_ref}': {switch_base['error']}")
-            return json.dumps(result, indent=2)
-        result["base_commit"] = switch_base.get("commit_sha", "unknown")
-        result["timing"]["checkout_base"] = round(time.time() - t0, 1)
-        result["phases_completed"].append("checkout_base")
+        # --- Phase 1: Switch to base_ref (skipped in cross-repo mode) ---
+        if not head_module_dir:
+            t0 = time.time()
+            switch_base = json.loads(git_switch_ref(workspace_id, base_ref, module_dir))
+            if "error" in switch_base:
+                result["status"] = "failure"
+                result["errors"].append(f"Failed to checkout base_ref '{base_ref}': {switch_base['error']}")
+                return json.dumps(result, indent=2)
+            result["base_commit"] = switch_base.get("commit_sha", "unknown")
+            result["timing"]["checkout_base"] = round(time.time() - t0, 1)
+            result["phases_completed"].append("checkout_base")
 
-        if not example_dir.is_dir():
+        if not base_example_dir.is_dir():
             result["status"] = "failure"
             result["errors"].append(
                 f"Example directory 'examples/{example}' not found at base_ref '{base_ref}'"
@@ -201,17 +227,20 @@ def run_upgrade_test(
         # --- Phase 2: Init + Apply at base_ref ---
         t0 = time.time()
         init_cmd = ["terraform", "init", "-input=false", "-no-color"]
-        init_result = _run_tf(init_cmd, example_dir, tf_data_dir)
+        init_result = _run_tf(init_cmd, base_example_dir, tf_data_dir)
         if init_result["exit_code"] != 0:
             result["status"] = "failure"
             result["errors"].append(f"terraform init failed at base_ref: {init_result['stderr'][:500]}")
             return json.dumps(result, indent=2)
         result["phases_completed"].append("init_base")
 
-        apply_cmd = ["terraform", "apply", "-input=false", "-no-color", "-auto-approve"]
+        apply_cmd = [
+            "terraform", "apply", "-input=false", "-no-color", "-auto-approve",
+            f"-state={state_path}",
+        ]
         if var_file:
             apply_cmd.append(f"-var-file={var_file}")
-        apply_result = _run_tf(apply_cmd, example_dir, tf_data_dir, timeout=1200)
+        apply_result = _run_tf(apply_cmd, base_example_dir, tf_data_dir, timeout=1200)
         result["timing"]["deploy_base"] = round(time.time() - t0, 1)
 
         base_deploy = {
@@ -227,23 +256,25 @@ def run_upgrade_test(
 
         result["base_deploy"] = base_deploy
         result["phases_completed"].append("apply_base")
+        deployed = True
 
         # --- Phase 3: Idempotency check at base_ref ---
         t0 = time.time()
         idem_cmd = [
             "terraform", "plan", "-input=false", "-no-color",
             "-detailed-exitcode", "-out=idempotency-check",
+            f"-state={state_path}",
         ]
         if var_file:
             idem_cmd.append(f"-var-file={var_file}")
-        idem_result = _run_tf(idem_cmd, example_dir, tf_data_dir)
+        idem_result = _run_tf(idem_cmd, base_example_dir, tf_data_dir)
         result["timing"]["idempotency_base"] = round(time.time() - t0, 1)
 
         if idem_result["exit_code"] == 0:
             result["base_idempotency"] = {"status": "pass", "unexpected_changes": 0}
         elif idem_result["exit_code"] == 2:
             show_cmd = ["terraform", "show", "-json", "-no-color", "idempotency-check"]
-            show_result = _run_tf(show_cmd, example_dir, tf_data_dir, timeout=60)
+            show_result = _run_tf(show_cmd, base_example_dir, tf_data_dir, timeout=60)
             idem_summary, idem_changes = _parse_plan_json(show_result)
             result["base_idempotency"] = {
                 "status": "fail",
@@ -257,18 +288,19 @@ def run_upgrade_test(
             }
         result["phases_completed"].append("idempotency_base")
 
-        # --- Phase 4: Switch to head_ref ---
-        t0 = time.time()
-        switch_head = json.loads(git_switch_ref(workspace_id, head_ref, module_dir))
-        if "error" in switch_head:
-            result["status"] = "failure"
-            result["errors"].append(f"Failed to checkout head_ref '{head_ref}': {switch_head['error']}")
-            return json.dumps(result, indent=2)
-        result["head_commit"] = switch_head.get("commit_sha", "unknown")
-        result["timing"]["checkout_head"] = round(time.time() - t0, 1)
-        result["phases_completed"].append("checkout_head")
+        # --- Phase 4: Switch to head_ref (skipped in cross-repo mode) ---
+        if not head_module_dir:
+            t0 = time.time()
+            switch_head = json.loads(git_switch_ref(workspace_id, head_ref, module_dir))
+            if "error" in switch_head:
+                result["status"] = "failure"
+                result["errors"].append(f"Failed to checkout head_ref '{head_ref}': {switch_head['error']}")
+                return json.dumps(result, indent=2)
+            result["head_commit"] = switch_head.get("commit_sha", "unknown")
+            result["timing"]["checkout_head"] = round(time.time() - t0, 1)
+            result["phases_completed"].append("checkout_head")
 
-        if not example_dir.is_dir():
+        if not head_example_dir.is_dir():
             result["status"] = "failure"
             result["errors"].append(
                 f"Example directory 'examples/{example}' not found at head_ref '{head_ref}' "
@@ -279,7 +311,7 @@ def run_upgrade_test(
         # --- Phase 5: Init -upgrade + Plan at head_ref (DO NOT APPLY) ---
         t0 = time.time()
         upgrade_init_cmd = ["terraform", "init", "-upgrade", "-input=false", "-no-color"]
-        upgrade_init = _run_tf(upgrade_init_cmd, example_dir, tf_data_dir)
+        upgrade_init = _run_tf(upgrade_init_cmd, head_example_dir, tf_data_dir)
         if upgrade_init["exit_code"] != 0:
             result["status"] = "failure"
             result["errors"].append(
@@ -290,10 +322,11 @@ def run_upgrade_test(
 
         upgrade_plan_cmd = [
             "terraform", "plan", "-input=false", "-no-color", "-out=upgrade-plan",
+            f"-state={state_path}",
         ]
         if var_file:
             upgrade_plan_cmd.append(f"-var-file={var_file}")
-        upgrade_plan = _run_tf(upgrade_plan_cmd, example_dir, tf_data_dir, timeout=600)
+        upgrade_plan = _run_tf(upgrade_plan_cmd, head_example_dir, tf_data_dir, timeout=600)
         result["timing"]["plan_upgrade"] = round(time.time() - t0, 1)
 
         if upgrade_plan["exit_code"] not in (0, 2):
@@ -305,7 +338,7 @@ def run_upgrade_test(
 
         # Parse the upgrade plan
         show_cmd = ["terraform", "show", "-json", "-no-color", "upgrade-plan"]
-        show_result = _run_tf(show_cmd, example_dir, tf_data_dir, timeout=60)
+        show_result = _run_tf(show_cmd, head_example_dir, tf_data_dir, timeout=60)
         upgrade_summary, upgrade_changes = _parse_plan_json(show_result)
 
         result["upgrade_plan_summary"] = upgrade_summary
@@ -340,17 +373,45 @@ def run_upgrade_test(
         result["errors"].append(f"Unexpected error: {exc}")
 
     finally:
-        # --- Phase 6: Cleanup (always runs unless cleanup=false) ---
-        if cleanup:
+        # --- Phase 6: Cleanup (always runs unless cleanup=false or nothing deployed) ---
+        if cleanup and deployed:
             t0 = time.time()
-            destroy_result = _do_destroy(example_dir, tf_data_dir, var_file)
-            result["destroy_result"] = {
-                "status": "success" if destroy_result["exit_code"] == 0 else "failure",
-                "exit_code": destroy_result["exit_code"],
-            }
-            if destroy_result["exit_code"] != 0:
-                result["destroy_result"]["error"] = destroy_result["stderr"][:500]
-                result["errors"].append("terraform destroy failed -- resources may be leaked")
+            destroy_dir: Path | None = None
+
+            if head_example_dir.is_dir():
+                # Prefer head dir: providers already upgraded, consistent with plan state
+                destroy_dir = head_example_dir
+            elif not head_module_dir:
+                # Single-repo mode: example may have been removed at head_ref.
+                # Switch back to base_ref to recover the config for destroy.
+                try:
+                    json.loads(git_switch_ref(workspace_id, base_ref, module_dir))
+                except Exception:
+                    pass
+                if base_example_dir.is_dir():
+                    destroy_dir = base_example_dir
+            elif base_example_dir.is_dir():
+                # Cross-repo mode: fall back to base dir
+                destroy_dir = base_example_dir
+
+            if destroy_dir is not None:
+                destroy_result = _do_destroy(destroy_dir, tf_data_dir, var_file, state_path)
+                result["destroy_result"] = {
+                    "status": "success" if destroy_result["exit_code"] == 0 else "failure",
+                    "exit_code": destroy_result["exit_code"],
+                }
+                if destroy_result["exit_code"] != 0:
+                    result["destroy_result"]["error"] = destroy_result["stderr"][:500]
+                    result["errors"].append("terraform destroy failed -- resources may be leaked")
+            else:
+                result["destroy_result"] = {
+                    "status": "failure",
+                    "error": "Example directory not found for destroy -- resources may be leaked",
+                }
+                result["errors"].append(
+                    "terraform destroy skipped -- example dir not found, resources may be leaked"
+                )
+
             result["timing"]["destroy"] = round(time.time() - t0, 1)
             result["phases_completed"].append("destroy")
 


### PR DESCRIPTION
Fixes all feedback from the Copilot review on #3, plus issues escalated by an independent rubber-duck critique.

## Changes by file

### `tools/upgrade_test.py`
- **Remove unused `_run` import** (issue 6)
- **Externalize `terraform.tfstate`** to `.tf-state/<example>/` outside the repo tree so `git clean` never deletes it (issue 7 / rubber-duck escalation)
- **Track `deployed` flag** — destroy only runs when resources were actually applied, preventing spurious destroy errors (issue 1)
- **Rewrite `finally` block** — when the example dir is missing at `head_ref`, switches back to `base_ref` to recover the Terraform config before destroying, preventing real resource leaks (issue 1 rubber-duck escalation)
- **Add `head_module_dir` parameter** to `run_upgrade_test` for cross-repo upgrade testing — when set, skips `git_switch_ref` and uses the separately-cloned head directory instead (rubber-duck new finding)
- **Pass `-state=<path>`** to all `terraform apply`, `plan`, and `destroy` invocations

### `tools/git_ops.py`
- **Add `--exclude=*.tfstate --exclude=*.tfstate.backup`** to `git clean` (issue 7 belt-and-suspenders)
- **Add `add_remote()` `@ai_function`** — adds and fetches a second remote in an existing clone, enabling cross-repo upgrade testing without re-cloning

### `tools/reporting.py`
- **Add `run_id: str = ""`** parameter to `generate_test_report`; keep env-var as fallback (issue 3)
- **Add `deploy_results` and `findings`** to the return dict so `store_test_run` receives real data instead of empty lists (issue 2)

### `tools/tracking.py`
- **Remove unused imports**: `asdict`, `dataclass`, `field`, `Path` (issue 8)

### `tools/github_ops.py`
- **Fix dead `try/except`** in `get_workflow_run_status` — wrap with `json.dumps(json.loads(...))` so the `JSONDecodeError` handler can actually fire (issue 9)

### `main.py`
- **Add all 9 missing tools to `ALL_TOOLS`**: `git_switch_ref`, `run_upgrade_test`, `store_test_run`, `query_findings`, `query_module_health`, `query_test_history`, `download_workflow_artifacts`, `get_workflow_run_status`, `add_remote` (issue 4)
- **Fix `requires_confirmation` in batch mode** — `sys.exit(1)` with an error message instead of silently logging a warning (issue 10 rubber-duck escalation)

### `request.py`
- **Add `head_module_source: str = ""`** field to `TestRequest` for cross-repo upgrade scenarios
- **Update `to_agent_message()`** to surface `head_module_source` when set

### `.github/workflows/run-test.yml`
- **Fix `discover` job module source detection**: `*/*` glob → `=~ ^[^/]+/[^/]+$` regex so registry addresses like `Azure/avm-res.../azurerm` are not misidentified as `org/repo` (issue 5)
- **Fix `deploy` job module source handling**: replace the unconditional GitHub URL construction with the same `=~ ^[^/]+/[^/]+$` guard + explicit `exit 1` for registry/unsupported formats (issue 5)
- **Add `github_repo` input** to both `workflow_dispatch` and `workflow_call` blocks (issue 11)
- **Fix PR comment step**: use `COMMENT_REPO="${{ inputs.github_repo || inputs.module_source }}"` so registry/URL module sources don't break the `gh pr comment` call (issue 11)